### PR TITLE
Implement Platform Isolation for Teacher/Student Model Provider compliance

### DIFF
--- a/infra/scripts/ai_config.py
+++ b/infra/scripts/ai_config.py
@@ -110,6 +110,13 @@ def filter_provider_transfer_compliant_models(deployment, role, selected_platfor
 def get_deployment_names(ai_config, regions, role='teacher', selected_platforms=None):
     deployments=ai_config['deployments'] if 'deployments' in ai_config else []
 
-    deployments = filter(lambda d: role in d['roles'] and Descriptor(d).is_supported_in_regions(regions) and filter_provider_transfer_compliant_models(d, role, selected_platforms), deployments)
+    deployment_filter = lambda d: (
+        role in d['roles']
+            and Descriptor(d).is_supported_in_regions(regions)
+            and filter_provider_transfer_compliant_models(d, role, selected_platforms)
+    )
+
+    deployments = filter(deployment_filter, deployments)
+
     deploymentNames = map(lambda d: d['name'], deployments)
     return list(deploymentNames)

--- a/infra/scripts/ai_config.py
+++ b/infra/scripts/ai_config.py
@@ -72,42 +72,44 @@ def get_regions(aiConfig):
     regions = set([region for d in deployments for region in d['regions']])
     return regions
 
+def filter_provider_transfer_compliant_models(deployment, role, selected_platforms):
+    """
+    Ensures platform consistency for teacher and student model selections to comply with 
+    model provider licensing constraints.
+    
+    Once a teacher or student model has been selected from a specific platform (e.g., Azure OpenAI, 
+    OpenAI, etc.), this function restricts subsequent teacher/student model selections to only 
+    include models from that same platform. This prevents mixing platforms within the teaching 
+    workflow, which is required to comply with licensing terms from model providers that restrict
+    using their models to train competing models from other providers.
+    
+    Args:
+        deployment: A deployment dictionary containing platform and role information
+        role: The role being selected for (e.g., 'teacher', 'student')
+        selected_platforms: Dictionary of already selected platforms by role
+        
+    Returns:
+        bool: True if the deployment should be included in the available options
+    """
+    if not selected_platforms:
+        return True
+    
+    platform = deployment.get('platform')
+    if not platform:
+        return True
+        
+    # If this is a teacher/student role and a platform has been selected for any teacher/student role,
+    # only include deployments with the same platform
+    if role in ['teacher', 'student']:
+        for selected_role, selected_platform in selected_platforms.items():
+            if selected_role in ['teacher', 'student']:
+                return platform == selected_platform
+    
+    return True
+
 def get_deployment_names(ai_config, regions, role='teacher', selected_platforms=None):
     deployments=ai_config['deployments'] if 'deployments' in ai_config else []
 
-    def isolate_teaching_platform(deployment):
-        """
-        Ensures platform consistency for teacher and student model selections to comply with 
-        model provider licensing constraints.
-        
-        Once a teacher or student model has been selected from a specific platform (e.g., Azure OpenAI, 
-        OpenAI, etc.), this function restricts subsequent teacher/student model selections to only 
-        include models from that same platform. This prevents mixing platforms within the teaching 
-        workflow, which is required to comply with licensing terms from model providers that restrict
-        using their models to train competing models from other providers.
-        
-        Args:
-            deployment: A deployment dictionary containing platform and role information
-            
-        Returns:
-            bool: True if the deployment should be included in the available options
-        """
-        if not selected_platforms:
-            return True
-        
-        platform = deployment.get('platform')
-        if not platform:
-            return True
-            
-        # If this is a teacher/student role and a platform has been selected for any teacher/student role,
-        # only include deployments with the same platform
-        if role in ['teacher', 'student']:
-            for selected_role, selected_platform in selected_platforms.items():
-                if selected_role in ['teacher', 'student']:
-                    return platform == selected_platform
-        
-        return True
-
-    deployments = filter(lambda d: role in d['roles'] and Descriptor(d).is_supported_in_regions(regions) and isolate_teaching_platform(d), deployments)
+    deployments = filter(lambda d: role in d['roles'] and Descriptor(d).is_supported_in_regions(regions) and filter_provider_transfer_compliant_models(d, role, selected_platforms), deployments)
     deploymentNames = map(lambda d: d['name'], deployments)
     return list(deploymentNames)

--- a/infra/scripts/ai_config.py
+++ b/infra/scripts/ai_config.py
@@ -75,7 +75,23 @@ def get_regions(aiConfig):
 def get_deployment_names(ai_config, regions, role='teacher', selected_platforms=None):
     deployments=ai_config['deployments'] if 'deployments' in ai_config else []
 
-    def should_include_deployment(deployment):
+    def isolate_teaching_platform(deployment):
+        """
+        Ensures platform consistency for teacher and student model selections to comply with 
+        model provider licensing constraints.
+        
+        Once a teacher or student model has been selected from a specific platform (e.g., Azure OpenAI, 
+        OpenAI, etc.), this function restricts subsequent teacher/student model selections to only 
+        include models from that same platform. This prevents mixing platforms within the teaching 
+        workflow, which is required to comply with licensing terms from model providers that restrict
+        using their models to train competing models from other providers.
+        
+        Args:
+            deployment: A deployment dictionary containing platform and role information
+            
+        Returns:
+            bool: True if the deployment should be included in the available options
+        """
         if not selected_platforms:
             return True
         
@@ -92,6 +108,6 @@ def get_deployment_names(ai_config, regions, role='teacher', selected_platforms=
         
         return True
 
-    deployments = filter(lambda d: role in d['roles'] and Descriptor(d).is_supported_in_regions(regions) and should_include_deployment(d), deployments)
+    deployments = filter(lambda d: role in d['roles'] and Descriptor(d).is_supported_in_regions(regions) and isolate_teaching_platform(d), deployments)
     deploymentNames = map(lambda d: d['name'], deployments)
     return list(deploymentNames)


### PR DESCRIPTION
# Implement Platform Isolation for Teacher/Student Model Selection

## Summary

This PR implements platform isolation for teacher/student model selection to ensure licensing compliance by enforcing that teacher and student models use the same underlying platform provider.

### Key Changes

- **Platform Isolation Logic**: Once a teacher or student model is selected from a specific platform (e.g., Azure OpenAI, Azure AI Foundry Serverless), subsequent teacher/student model selections are restricted to only models from that same platform

- **Licensing Compliance**: Prevents mixing platforms within the teaching workflow, which is required to comply with licensing terms from model providers that restrict using their models to train competing models from other providers

### Files Modified

- `infra/scripts/ai_config.py`: Updated platform filtering logic and function structure
- `infra/scripts/configure_models.py`: Updated function call to use new parameter name

### Behavior Change

**After**: If a teacher model is selected from Platform A, only student models from Platform A are available for selection

This ensures that all teacher/student model pairs use the same underlying platform provider, maintaining compliance with licensing restrictions.