### PR TITLE
Fix Dependabot alerts via non-major bumps (+ remove unused PyPDF2)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
 ipykernel==6.29.5
 datasets==4.0.0
 openai==1.95.1
-PyPDF2==3.0.1
 transformers==4.53.2
 langchain-experimental==0.3.4
 langchain-openai==0.3.28
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 PyYAML==6.0.1
 coloredlogs==15.0.1
 mdc==1.2.1
@@ -28,7 +27,7 @@ azureml-core==1.60.0.post1
 msrestazure==0.6.4.post1
 azure-mgmt-resource==24.0.0
 # Infra tests
-requests==2.32.3
+requests==2.33.0
 click==8.1.7
 rich==13.8.1
 rich-click==1.8.3


### PR DESCRIPTION
## Summary

Remediates the Dependabot alerts that can be fixed **without a major version bump**, plus removes the deprecated, unused `PyPDF2` package. Per request, alerts whose only patched version is a major release are intentionally **deferred** (not applied).

## Applied (non-major bumps) ✅

| Alert | Package | Old → New | CVE | Severity | Bump |
|---|---|---|---|---|---|
| #24 | python-dotenv | 1.0.1 → 1.2.2 | CVE-2026-28684 | medium | minor |
| #20, #13 | requests | 2.32.3 → 2.33.0 | CVE-2026-25645 + CVE-2024-47081 | medium | minor |
| #1 | PyPDF2 | **removed** | CVE-2023-36464 | medium | removal (no patch exists; unused) |

`requests 2.33.0` covers both alerts (≥ 2.32.4 and ≥ 2.33.0). PyPDF2 is confirmed not imported anywhere — the only PDF helper, `utils.get_pdf_image`, uses `wand`.

## Deferred — first patched version requires a MAJOR bump ⏸️

These are left at their current versions because Dependabot's first patched version is a major release (vulnerable range is everything below it, so no minor/patch fix exists):

| Alert | Package | Current → First patched | Severity | Why deferred |
|---|---|---|---|---|
| #19 | black | 25.1.0 → 26.3.1 | high | CalVer major (25→26); also requires `pathspec>=1.0.0`, conflicting with `azureml-core 1.60.0.post1` (`pathspec<1.0.0`). Dev/format tool only. |
| #22 | pytest | 8.1.2 → 9.0.3 | medium | major (8→9). Test tool only. |
| #21 | transformers | 4.53.2 → 5.0.0rc3 | medium | major (4→5) **and** a pre-release. |
| #23 | langchain-openai | 0.3.28 → 1.1.14 | low | major (0.x→1.x); pulls `openai>=2.26.0` (vs pinned `openai==1.95.1`). `langchain` is unused in this repo. |

## Validation

- The original `requirements.txt` resolves cleanly; this change keeps the dependency set otherwise intact.
- The non-major bumps were dry-run resolved: everything resolves **except** the `llmscout` git dependency, which hard-pins `python-dotenv==1.0.1` and `requests==2.32.3` (see its `pyproject.toml`). So a clean `pip install -r requirements.txt` still requires a **companion update to the llmscout repo** to relax those two pins.
- Tests: the only tests are `infra/tests/*`, which need live Azure credentials + network — skipped.

## Recommended follow-ups
- Update the `llmscout` repo to relax its `python-dotenv` / `requests` pins so this repo resolves cleanly.
- Separately decide on the deferred (major-bump) alerts: e.g. bump `openai`→2.x + drop unused `langchain-*`; bump `pytest`→9.x; bump `transformers`→5.x; and bump `azureml-core` to unblock `black`→26.x.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;